### PR TITLE
updated unsupported datatypes to Int

### DIFF
--- a/server/schemas/typeDefs.js
+++ b/server/schemas/typeDefs.js
@@ -6,7 +6,8 @@ type User {
     email: String
     password: String
     bookGoal: Int
-    goalDate: Date
+    # "Date" would be a custom type -> easier to use unix timestamp and convert it
+    goalDate: Int
     bookCompleted: Int
     Books: [Book]
   }
@@ -46,13 +47,14 @@ type User {
   }
 
   type Mutation {
-    addUser(userName: String!, email: String!, password: String!, bookGoal: Number, goalDate: Date): Auth
+    # "Date" would be a custom type -> easier to use unix timestamp and convert it
+    addUser(userName: String!, email: String!, password: String!, bookGoal: Int, goalDate: Int): Auth
     login(email: String!, password: String!): Auth
     addBook(title: String!): Book
     addBookComment(bookId: ID!, commentText: String!): Book
     removeBook(title: String!): Book
     removeBookComment(bookId: ID!, commentText: String!): Book
-    updateBookRating(bookRating: Number): Book 
+    updateBookRating(bookRating: Int): Book 
   }
 `;
 //TODO: Need a way to update book boolean fields -  mutation


### PR DESCRIPTION
See comments in typeDefs - custom datatypes are annoying to set up and we're only using it once.  Easier to set as an `Int` and convert it using JS Date object methods.